### PR TITLE
Feat: add interactive starfield background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
 import SmoothScroll from "@/components/smooth-scroll"
+import InteractiveBackground from "@/components/ui/interactivebackground";
 
 export const metadata: Metadata = {
   title: "The FOSS Club",
@@ -27,6 +28,7 @@ export default function RootLayout({
         <link rel="icon" href="/FOSS.ico" />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
+        <InteractiveBackground />
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"

--- a/components/grid-background.tsx
+++ b/components/grid-background.tsx
@@ -34,7 +34,7 @@ export default function GridBackground() {
       }
     }
 
-    const drawDots = (width: number, height: number) => {
+/*    const drawDots = (width: number, height: number) => {
       if (!ctx) return
       ctx.clearRect(0, 0, width, height)
       const isDark = resolvedTheme === "dark"
@@ -48,13 +48,13 @@ export default function GridBackground() {
         ctx.fill()
       }
     }
-
+*/   
     const resizeCanvas = () => {
       const rect = container.getBoundingClientRect()
       canvas.width = Math.round(rect.width)
       canvas.height = Math.round(rect.height)
       generateDots(canvas.width, canvas.height)
-      drawDots(canvas.width, canvas.height)
+      /*drawDots(canvas.width, canvas.height)*/
     }
 
     resizeCanvas()

--- a/components/hero-sphere.tsx
+++ b/components/hero-sphere.tsx
@@ -61,7 +61,13 @@ export default function HeroSphere() {
       }
       if (!ctx) return
       ctx.clearRect(0, 0, width, height)
-
+      const glow = ctx.createRadialGradient(width / 2, height / 2, 0,
+          width / 2, height / 2, radius * 1.6)
+      glow.addColorStop(0, "rgba(34,197,94,0.35)")
+      glow.addColorStop(0.5, "rgba(34,197,94,0.12)")
+      glow.addColorStop(1, "rgba(34,197,94,0)")
+      ctx.fillStyle = glow
+      ctx.fillRect(0, 0, width, height)
       for (const point of points.current) {
         point.angle += point.speed
 
@@ -143,8 +149,7 @@ export default function HeroSphere() {
       transition={{ duration: 1 }}
       className="relative"
     >
-      <canvas ref={canvasRef} width={500} height={500} className="opacity-90" />
+    <canvas ref={canvasRef} width={500} height={500} className="opacity-90" />
     </m.div>
   )
 }
-

--- a/components/occ-scroll-card.tsx
+++ b/components/occ-scroll-card.tsx
@@ -18,7 +18,7 @@ const defaultOccCards: OCCCardItem[] = [
     id: "occ-3",
     title: "AI | AI Slop | ML | Linux | AI in Gamedev",
     date: "18 January, 2026",
-    speakers: "Tooshar Bharadwaj, Karan Veer Singh, Prakahar Sharma",
+    speakers: "Tooshar Bhardwaj, Karan Veer Singh, Prakahar Sharma",
     image: "occ/occ-3.webp",
   },
   {

--- a/components/ui/interactivebackground.tsx
+++ b/components/ui/interactivebackground.tsx
@@ -13,7 +13,7 @@ interface Star {
   twinkleSpeed: number
 }
 
-const STAR_COUNT = 500
+const STAR_COUNT = 700
 const REPULSION_RADIUS = 50
 const REPULSION_FORCE = 1.2
 const FRICTION = 0.76

--- a/components/ui/interactivebackground.tsx
+++ b/components/ui/interactivebackground.tsx
@@ -13,9 +13,9 @@ interface Star {
   twinkleSpeed: number
 }
 
-const STAR_COUNT = 700
+const STAR_COUNT = 300
 const REPULSION_RADIUS = 50
-const REPULSION_FORCE = 1.2
+const REPULSION_FORCE = 1.8
 const FRICTION = 0.76
 const BASE_SPEED = 0.09
 const STAR_COLOR = "34,197,94"

--- a/components/ui/interactivebackground.tsx
+++ b/components/ui/interactivebackground.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+interface Star {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  radius: number
+  opacity: number
+  targetOpacity: number
+  twinkleSpeed: number
+}
+
+const STAR_COUNT = 500
+const REPULSION_RADIUS = 50
+const REPULSION_FORCE = 1.2
+const FRICTION = 0.76
+const BASE_SPEED = 0.09
+const STAR_COLOR = "34,197,94"
+
+function rand(a: number, b: number) {
+  return a + Math.random() * (b - a)
+}
+
+function makeStar(w: number, h: number): Star {
+  const angle = Math.random() * Math.PI * 2
+  return {
+    x: Math.random() * w,
+    y: Math.random() * h,
+    vx: Math.cos(angle) * BASE_SPEED,
+    vy: Math.sin(angle) * BASE_SPEED,
+    radius: rand(0.89, 2.6),
+    opacity: rand(0.08, 0.45),
+    targetOpacity: rand(0.10, 0.65),
+    twinkleSpeed: rand(0.08, 0.22),
+  }
+}
+
+export default function InteractiveBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const starsRef = useRef<Star[]>([])
+  const mouseRef = useRef({ x: -9999, y: -9999 })
+  const rafRef = useRef<number>(0)
+  const sizeRef = useRef({ w: 0, h: 0 })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    const init = () => {
+      canvas.width = window.innerWidth
+      canvas.height = window.innerHeight
+      sizeRef.current = { w: canvas.width, h: canvas.height }
+      starsRef.current = Array.from({ length: STAR_COUNT }, () =>
+        makeStar(canvas.width, canvas.height)
+      )
+    }
+
+    const onMouseMove = (e: MouseEvent) => {
+      mouseRef.current = { x: e.clientX, y: e.clientY }
+    }
+
+    const onMouseLeave = () => {
+      mouseRef.current = { x: -9999, y: -9999 }
+    }
+
+    const draw = () => {
+      const { w, h } = sizeRef.current
+      ctx.clearRect(0, 0, w, h)
+      const { x: mx, y: my } = mouseRef.current
+
+      for (const s of starsRef.current) {
+        const dx = s.x - mx
+        const dy = s.y - my
+        const dist = Math.sqrt(dx * dx + dy * dy)
+
+        if (dist < REPULSION_RADIUS && dist > 0) {
+          const force = (1 - dist / REPULSION_RADIUS) * REPULSION_FORCE
+          s.vx += (dx / dist) * force
+          s.vy += (dy / dist) * force
+        }
+
+        s.vx *= FRICTION
+        s.vy *= FRICTION
+
+        const speed = Math.sqrt(s.vx * s.vx + s.vy * s.vy)
+        if (speed < BASE_SPEED) {
+          s.vx += (s.vx / (speed || 1)) * 0.01
+          s.vy += (s.vy / (speed || 1)) * 0.01
+        }
+
+        s.x += s.vx
+        s.y += s.vy
+
+        if (s.x < -2) s.x = w + 2
+        if (s.x > w + 2) s.x = -2
+        if (s.y < -2) s.y = h + 2
+        if (s.y > h + 2) s.y = -2
+
+        s.opacity += (s.targetOpacity - s.opacity) * s.twinkleSpeed
+        if (Math.abs(s.opacity - s.targetOpacity) < 0.01) {
+          s.targetOpacity = rand(0.04, 0.65)
+          s.twinkleSpeed = rand(0.008, 0.022)
+        }
+
+        ctx.beginPath()
+        ctx.arc(s.x, s.y, s.radius, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${STAR_COLOR},${s.opacity.toFixed(3)})`
+        ctx.fill()
+      }
+
+      rafRef.current = requestAnimationFrame(draw)
+    }
+
+    init()
+    window.addEventListener("resize", init)
+    window.addEventListener("mousemove", onMouseMove)
+    window.addEventListener("mouseleave", onMouseLeave)
+    rafRef.current = requestAnimationFrame(draw)
+
+    return () => {
+      cancelAnimationFrame(rafRef.current)
+      window.removeEventListener("resize", init)
+      window.removeEventListener("mousemove", onMouseMove)
+      window.removeEventListener("mouseleave", onMouseLeave)
+    }
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none fixed inset-0 z-0"
+    />
+  )
+}


### PR DESCRIPTION
## Changes
- Add `interactivebackground.tsx` — canvas-based starfield, stars drift
  freely and scatter from cursor on hover, styled in site green (`#22c55e`)
- Mount component in `app/layout.tsx`
- Comment out `grid-background.tsx` to avoid visual conflict with starfield
- Fix typo in `occ-scroll-card.tsx`: 'Bharadwaj' → 'Bhardwaj'

## Behavior
- Stars drift freely, wrap around edges, and twinkle independently
- Cursor repels nearby stars on hover