### PR TITLE
feat(navbar/UI): add Application form link for core-team 2026 to navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -139,11 +139,11 @@ export default function Navbar({ activeSection }: NavbarProps) {
                 ))}
                 <li className="flex items-center space-x-4">
                   <Link
-                    href="/fosshack"
+                    href="https://opnform.com/forms/foss-club-dtc-core-team-application-2026-gevoue"
                     target="_blank"
-                    className="px-4 py-2 bg-gradient-green text-white rounded-full text-sm font-medium hover:opacity-90 transition-opacity btn-glow"
+                    className="px-4 py-2 bg-gradient-green text-white rounded-full text-sm font-medium hover:opacity-90 transition-opacity btn-glow whitespace-nowrap"
                   >
-                    FOSSHack2026
+                    APPLY NOW
                   </Link>
                   {/* <Link
                     href="/login"


### PR DESCRIPTION
## Description
this PR replaces the outdated `FOSSHACK2026` text with `APPLY NOW` and adds the form link

### More info
+ replaced with FOSSHACK2026 text
+ the countdown page is still there and no changes are made to it
+ only changes made are to the navbar and the additon of the  [form link](https://opnform.com/forms/foss-club-dtc-core-team-application-2026-gevoue) to the navbar component
+ the changes are tested with `npm run dev` and `npm run build` and everything worked
